### PR TITLE
Dockerfile relayer backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16-alpine
+
+WORKDIR /home/relayer/relayer-backend
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+ENTRYPOINT [ "node",  "dist/index.js" ]
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine
 
+RUN mkdir -p /home/relayer/relayer-backend/chain-data 
+
 WORKDIR /home/relayer/relayer-backend
 
 COPY package*.json ./

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,3 +28,22 @@ By default application will process blocks from the chains specified in `config/
 - `npm run build` - build project
 
 License: Apache-2.0
+
+## Docker "local mode"
+
+Follow the instructions to run over a docker container:
+
+- https://github.com/subspace/subspace-relayer/blob/main/backend/relayer-archive.md
+
+## Docker "live mode"
+
+Follow the instructions to run over a docker container:
+
+- https://github.com/subspace/subspace-relayer/blob/main/backend/relayer-live.md
+
+### Download full chain from genesis.
+
+Follow the instructions to run the download tool:
+
+- https://github.com/subspace/subspace-relayer/blob/main/backend/relayer-download.md
+

--- a/backend/relayer-archive.md
+++ b/backend/relayer-archive.md
@@ -1,0 +1,59 @@
+# Configure relayer "local mode"
+
+- Get the latest relayer version and build it.
+
+```
+git clone https://github.com/subspace/subspace-relayer.git && cd subspace-relayer/backend
+```
+
+We have to made some manual configuration. As some of these are not static.
+
+- In the backend directory. Check that .env point to the local subspace-node-public container WS.
+
+```
+TARGET_CHAIN_URL="ws://subspace-node-public:9944"
+ACCOUNT_SEED="//Alice"
+```
+
+- In the backend directory (./src/config/archives.json). Configure the directory to add the chain data archives.
+
+```
+[
+  {
+    "url": "wss://kusama-rpc.polkadot.io",
+    "path": "/home/relayer/relayer-backend/chain-data/Kusama-archives/kusama-archive-2021-oct-23/"
+  }
+]
+```
+
+- With .env and archives.json edited, generate the dist folder that will run in the docker container with the current configuration.
+
+```
+    npm install
+    npm run build
+```
+
+# Building.
+
+- Generate the local image with the current configuration.
+
+```
+docker build . -t relayer-backend
+```
+
+# Runing
+
+- Run the image
+
+  - adding a volume that map a local directory to the docker container
+  - and to run the relayer backend in the docker subspace network where the nodes are running.
+
+- replace LOCAL_CHAIN_DATA_DIR with the path to the chain data archives.
+
+- pass archive parameter to the relayer backend ENTRYPOINT.
+
+```
+docker run -it --volume /mnt/LOCAL_CHAIN_DATA_DIR:/home/relayer/relayer-backend/chain-data --net subspace --name relayer-backend relayer-backend:latest archive
+
+```
+

--- a/backend/relayer-archive.md
+++ b/backend/relayer-archive.md
@@ -8,34 +8,38 @@ git clone https://github.com/subspace/subspace-relayer.git && cd subspace-relaye
 
 We have to made some manual configuration. As some of these are not static.
 
-- In the backend directory. Check that .env point to the local subspace-node-public container WS.
+- In the backend directory. Check that **.env** point to the local subspace-node-public container WS.
 
 ```
 TARGET_CHAIN_URL="ws://subspace-node-public:9944"
 ACCOUNT_SEED="//Alice"
 ```
 
-- In the backend directory (./src/config/archives.json). Configure the directory to add the chain data archives.
+- In the backend directory (./src/config/**archives.json**). Configure to add the chain data archives. For example:
 
 ```
 [
   {
-    "url": "wss://kusama-rpc.polkadot.io",
-    "path": "/home/relayer/relayer-backend/chain-data/Kusama-archives/kusama-archive-2021-oct-23/"
+    "url": "https://kusama-rpc.polkadot.io",
+    "path": "/home/relayer/relayer-backend/chain-data/Kusama-archives/kusama-archive-2021-oct-23"
+  },
+  {
+      "url": "https://altair.api.onfinality.io/public",
+      "path": "/home/relayer/relayer-backend/chain-data/Kusama-archives/altair-archive-2021-oct-23"
   }
 ]
 ```
 
-- With .env and archives.json edited, generate the dist folder that will run in the docker container with the current configuration.
+- With **.env** and **archives.json** edited, generate the dist folder that will run in the docker container with the current configuration.
 
 ```
-    npm install
+    npm i
     npm run build
 ```
 
 # Building.
 
-- Generate the local image with the current configuration.
+- Generate the local docker image with the current configuration.
 
 ```
 docker build . -t relayer-backend
@@ -43,17 +47,13 @@ docker build . -t relayer-backend
 
 # Runing
 
-- Run the image
+- Run the image:
 
-  - adding a volume that map a local directory to the docker container
-  - and to run the relayer backend in the docker subspace network where the nodes are running.
-
-- replace LOCAL_CHAIN_DATA_DIR with the path to the chain data archives.
-
-- pass archive parameter to the relayer backend ENTRYPOINT.
+  - --volume | map a local directory to the docker container.
+  - --net subspace | run the relayer backend in the docker subspace network where the container nodes are running.
+  - replace LOCAL_CHAIN_DATA_DIR with the path to the chain data archives.
+  - pass **archive** parameter to the ENTRYPOINT, to run the relayer in archive mode.
 
 ```
 docker run -it --volume /mnt/LOCAL_CHAIN_DATA_DIR:/home/relayer/relayer-backend/chain-data --net subspace --name relayer-backend relayer-backend:latest archive
-
 ```
-

--- a/backend/relayer-download.md
+++ b/backend/relayer-download.md
@@ -1,0 +1,33 @@
+# Configure relayer to download blocks from genesis.
+
+- Get the latest relayer version and build it.
+
+```
+git clone https://github.com/subspace/subspace-relayer.git && cd subspace-relayer/backend
+```
+
+We have to made some manual configuration. As some of these are not static.
+
+- In the backend directory. Check **.env** and set for example:
+
+```
+SOURCE_CHAIN_RPC=https://kusama-rpc.polkadot.io
+REPORT_PROGRESS_INTERVAL=10
+TARGET_DIR=/home/USER/kusama-data/kusama-08-nov-2021
+
+```
+
+- With **.env** and **archives.json** edited, generate the dist folder that will run in the docker container with the current configuration.
+
+```
+    npm i
+    npm run build
+```
+
+# Runing
+
+Run the block download tool with the following command:
+
+```
+node dist/tools/download-substrate-blocks.js
+```

--- a/backend/relayer-download.md
+++ b/backend/relayer-download.md
@@ -6,18 +6,7 @@
 git clone https://github.com/subspace/subspace-relayer.git && cd subspace-relayer/backend
 ```
 
-We have to made some manual configuration. As some of these are not static.
-
-- In the backend directory. Check **.env** and set for example:
-
-```
-SOURCE_CHAIN_RPC=https://kusama-rpc.polkadot.io
-REPORT_PROGRESS_INTERVAL=10
-TARGET_DIR=/home/USER/kusama-data/kusama-08-nov-2021
-
-```
-
-- With **.env** and **archives.json** edited, generate the dist folder that will run in the docker container with the current configuration.
+- Build to generate the dist folder
 
 ```
     npm i
@@ -26,8 +15,30 @@ TARGET_DIR=/home/USER/kusama-data/kusama-08-nov-2021
 
 # Runing
 
-Run the block download tool with the following command:
+Run the block download tool with the following command, set the env variables for each chain you want to download.
+
+For example:
 
 ```
-node dist/tools/download-substrate-blocks.js
+SOURCE_CHAIN_RPC="https://kusama-rpc.polkadot.io" REPORT_PROGRESS_INTERVAL=1 TARGET_DIR="/home/USER/kusama-data/kusama-08-nov-2021" node dist/tools/download-substrate-blocks.js
 ```
+
+Getting a similar output:
+
+```
+Retrieving last finalized block...
+Last finalized block is 10013216
+Downloading blocks into /home/USER/kusama-data/kusama-08-nov-2021
+Continuing downloading from block 11
+Downloaded block 11/10013216
+Downloaded block 12/10013216 (0.54 blocks/s)
+Downloaded block 13/10013216 (0.31 blocks/s)
+Downloaded block 14/10013216 (0.54 blocks/s)
+Downloaded block 15/10013216 (0.98 blocks/s)
+Downloaded block 16/10013216 (0.70 blocks/s)
+Downloaded block 17/10013216 (0.81 blocks/s)
+Downloaded block 18/10013216 (0.35 blocks/s)
+Downloaded block 19/10013216 (0.60 blocks/s)
+```
+
+*You can run this task in paralell for several chains.*

--- a/backend/relayer-live.md
+++ b/backend/relayer-live.md
@@ -1,0 +1,47 @@
+# Configure relayer "live mode"
+
+- Get the latest relayer version and build it.
+
+```
+git clone https://github.com/subspace/subspace-relayer.git && cd subspace-relayer/backend
+```
+
+We have to made some manual configuration. As some of these are not static.
+
+- In the backend directory. Check that .env point to the local subspace-node-public container WS.
+
+```
+TARGET_CHAIN_URL="ws://subspace-node-public:9944"
+ACCOUNT_SEED="//Alice"
+```
+
+- In the backend directory (./src/config/archives.json). Check if this file its empty.
+
+```
+[]
+```
+
+- With .env and archives.json edited, generate the dist folder that will run in the docker container with the current configuration.
+
+```
+    npm install
+    npm run build
+```
+
+# Building.
+
+- Generate the local image with the current configuration.
+
+```
+docker build . -t relayer-backend
+```
+
+# Runing
+
+- Run the image
+  - and to run the relayer backend in the docker subspace network where the nodes are running.
+
+```
+docker run -it --net subspace --name relayer-backend relayer-backend:latest
+
+```

--- a/backend/relayer-live.md
+++ b/backend/relayer-live.md
@@ -15,13 +15,7 @@ TARGET_CHAIN_URL="ws://subspace-node-public:9944"
 ACCOUNT_SEED="//Alice"
 ```
 
-- In the backend directory (./src/config/archives.json). Check if this file its empty.
-
-```
-[]
-```
-
-- With .env and archives.json edited, generate the dist folder that will run in the docker container with the current configuration.
+- With .env edited, generate the dist folder that will run in the docker container with the current configuration.
 
 ```
     npm install
@@ -30,7 +24,7 @@ ACCOUNT_SEED="//Alice"
 
 # Building.
 
-- Generate the local image with the current configuration.
+- Generate the local docker image with the current configuration.
 
 ```
 docker build . -t relayer-backend
@@ -38,10 +32,9 @@ docker build . -t relayer-backend
 
 # Runing
 
-- Run the image
-  - and to run the relayer backend in the docker subspace network where the nodes are running.
+- Run the image:
+  - --net subspace | run the relayer backend in the docker subspace network where the container nodes are running.
 
 ```
-docker run -it --net subspace --name relayer-backend relayer-backend:latest
-
+docker run -it  --net subspace --name relayer-backend relayer-backend:latest
 ```


### PR DESCRIPTION
This PR contains:

- Dockerfile to locally get a relayer container.
- Instructions to run relayer in archive and live mode using docker container.
- Instructions to run block downloader tool.
- Update relayer backend README.md

@isSerge, validate relayer instructions will be appreciated.
@nazar-pc, any comment about dockerfile and downloader tool is appreciated. 