### PR TITLE
Fix signed block validation to prevent runtime errors

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -65,7 +65,9 @@ export function blockToBinary(block: SignedBlockJsonRpc): Buffer {
 // disable eslint rules and allow 'any' because we're checking API response
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function isInstanceOfSignedBlockJsonRpc(object: any): object is SignedBlockJsonRpc {
-    return 'block' in object &&
+    return (
+        object &&
+        'block' in object &&
         'justifications' in object &&
         Array.isArray(object.block.extrinsics) &&
         Array.isArray(object.block.header.digest.logs) &&
@@ -73,7 +75,8 @@ export function isInstanceOfSignedBlockJsonRpc(object: any): object is SignedBlo
         typeof object.block.header.number === 'string' &&
         typeof object.block.header.stateRoot === 'string' &&
         typeof object.block.header.extrinsicsRoot === 'string' &&
-        typeof object.block.header.parentHash === 'string';
+        typeof object.block.header.parentHash === 'string'
+    );
 }
 
 enum DigestItemType {


### PR DESCRIPTION
Fixes following error:
```
[1636576444183] ERROR: TypeError: Cannot use 'in' operator to search for 'block' in undefined
    at isInstanceOfSignedBlockJsonRpc (/web/subspace/subspace-relayer/backend/dist/utils.js:58:20)
    at /web/subspace/subspace-relayer/backend/dist/httpApi.js:76:57
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async getBlockByNumber (/web/subspace/subspace-relayer/backend/dist/httpApi.js:64:19)
    at async RetryOperation._fn (/web/subspace/subspace-relayer/backend/node_modules/p-retry/index.js:50:12)
```