### PR TITLE
Refactor parachain table and row

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -23,19 +23,19 @@ const Header = () => {
     if (feedsTotals) {
       const acumulatedSizes = feedsTotals.reduce(
         (accumulator, currentValue) =>
-          accumulator + currentValue.size_.toNumber(),
+          accumulator + currentValue?.size_.toNumber() || 0,
         0
       );
       const acumulatedObjects = feedsTotals.reduce(
         (accumulator, currentValue) =>
-          accumulator + currentValue.count.toNumber(),
+          accumulator + currentValue?.count.toNumber() || 0,
         0
       );
       setAcumulatedSizes(acumulatedSizes);
       setAcumulatedObjects(acumulatedObjects);
     }
   }, [feedsTotals]);
-
+  
   // TODO: Card to component.
   return (
     <div className="header bg-gradient-gray-dark pb-4 pt-2 pt-md-4 pl-4 pr-9 ">

--- a/frontend/src/components/ParachainTable.tsx
+++ b/frontend/src/components/ParachainTable.tsx
@@ -1,84 +1,29 @@
-import React, { useContext, useEffect, useState } from "react";
-import { ApiPromiseContext, RelayerContextProvider } from "context";
+import { useState } from "react";
 import { Card, Container, Row, Table } from "reactstrap";
 import { parachains } from "config/AvailableParachain";
 import Header from "./Header";
 import ParachainRow from "./ParachainRow";
 import { ParachainProps } from "config/interfaces/Parachain";
-import { bytesToSize } from "components/utils";
 
 const ParachainTable = () => {
-  const { api, isApiReady } = useContext(ApiPromiseContext);
-  const [parachainsFeed, setParachainsFeeds] = useState<ParachainProps[]>([
-    ...parachains,
-  ]);
-
-  useEffect(() => {
-    if (!isApiReady) return;
-
-    api.rpc.chain
-      .subscribeNewHeads(async (lastHeader) => {
-        // TODO : Refactor with custom types
-
-        const signedBlock = await api.rpc.chain.getBlock(lastHeader.hash);
-        //TODO : Improve this each
-        signedBlock.block.extrinsics.forEach(
-          async ({ method: { method, section, args } }) => {
-            if (section === "feeds" && method === "put") {
-              const feed_id: number = api.registry
-                .createType("u64", args[0])
-                .toNumber();
-              const data: any = api.registry
-                .createType("Bytes", args[1])
-                .toHuman();
-              const metadata = JSON.parse(
-                api.registry.createType("Bytes", args[2]).toHuman() as string
-              );
-              const newParaFeed: ParachainProps = {
-                ...parachains[feed_id],
-                status: "Connected",
-                lastUpdate: Date.now(),
-                lastBlockHash: String(metadata.hash),
-                lastBlockHeight: Number(metadata.number),
-                blockSize: bytesToSize(data.length),
-                subspaceHash: signedBlock.block.header.hash.toHex(),
-              };
-              setParachainsFeeds((parachainsFeed) => {
-                const newParachainsFeed = [...parachainsFeed];
-                newParachainsFeed[feed_id] = newParaFeed;
-                return [...newParachainsFeed];
-              });
-            }
-          }
-        );
-      })
-      .catch((e) => console.error(e));
-  }, [api, isApiReady]);
+  const [parachainsFeed] = useState<ParachainProps[]>([...parachains]);
 
   return (
     <div>
-      <RelayerContextProvider>
-        <Header />
-      </RelayerContextProvider>
-      <Container className="pl-5 pr-5 pt-4" fluid>
+      <Header />
+      <Container className="pl-4 pr-4 pt-4" fluid>
         <Row>
           <div className="col">
             <Card className="shadow">
-              <Table className="table-flush align-items-center" responsive>
+              <Table size="md" className="align-items-center" responsive>
                 <thead className="thead-light">
                   <tr>
-                    <th scope="col">{"Chains"}</th>
-                    <th scope="col">{"Last Updated"}</th>
-                    <th scope="col" className="text-left">
-                      {"Last Block Hash"}
-                    </th>
-                    <th scope="col" className="text-left">
-                      {"Last Block Height"}
-                    </th>
-                    <th scope="col">{"Last Block Size"}</th>
-                    <th scope="col" className="text-right">
-                      {"Subspace Tx Hash"}
-                    </th>
+                    <th>{"Chains"}</th>
+                    <th>{"Last Updated"}</th>
+                    <th className="text-left">{"Last Block Hash"}</th>
+                    <th className="text-left">{"Last Block Height"}</th>
+                    <th>{"Storage"}</th>
+                    <th className="text-right">{"BLOCKS ARCHIVED"}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/components/utils.ts
+++ b/frontend/src/components/utils.ts
@@ -1,11 +1,17 @@
 export const bytesToSize = (bytes: number): string => {
-  if(bytes === 0) return '0 B';
+  if (bytes === 0) return "0 B";
   const sizes = ["Bytes", "KiB", "MiB", "GiB", "TiB"];
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   if (i === 0) return `${bytes} ${sizes[i]}`;
   return `${(bytes / 1024 ** i).toFixed(1)} ${sizes[i]}`;
 };
 
-export const prettyHash = (hash: string): string => {
-  return `${hash.slice(0, 14)}...${hash.slice(hash.length - 6)}`;
+export const prettyHash = (
+  hash: string,
+  initSlice: number,
+  lastsSlice: number
+): string => {
+  return `${hash.slice(0, initSlice)}...${hash.slice(
+    hash.length - lastsSlice
+  )}`;
 };

--- a/frontend/src/config/interfaces/Parachain.ts
+++ b/frontend/src/config/interfaces/Parachain.ts
@@ -1,12 +1,6 @@
 import { u64, Struct } from "@polkadot/types";
 
 export interface ParachainProps {
-  status?: string;
-  lastUpdate?: number;
-  lastBlockHeight?: number;
-  lastBlockHash?: string;
-  blockSize?: string;
-  subspaceHash?: string;
   url: string;
   paraId: number;
   feedId: number;
@@ -19,4 +13,9 @@ export interface ParachainProps {
 export interface Totals extends Struct {
   readonly size_: u64;
   readonly count: u64;
+}
+
+export interface Feed {
+  hash: string;
+  number: number;
 }

--- a/frontend/src/context/RelayerContext.tsx
+++ b/frontend/src/context/RelayerContext.tsx
@@ -5,7 +5,6 @@ import {
   RelayerContextType,
 } from "context/interfaces";
 import { Totals } from "config/interfaces/Parachain";
-
 import { parachains } from "config/AvailableParachain";
 import { ApiPromiseContext, SystemContext } from "context";
 import { ApiPromise } from "@polkadot/api";
@@ -30,6 +29,7 @@ export function RelayerContextProvider(
   const provider = useProvider();
   const { api, isApiReady } = useContext(ApiPromiseContext);
   const { header } = useContext(SystemContext);
+
   const [feedsTotals, setFeedsTotals] = useState<Totals[]>(
     Array<Totals>(parachains.length)
   );

--- a/frontend/src/hooks/WindowsSize.tsx
+++ b/frontend/src/hooks/WindowsSize.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+export function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+      });
+    }
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+}

--- a/frontend/src/layout/MainLayout.tsx
+++ b/frontend/src/layout/MainLayout.tsx
@@ -1,18 +1,20 @@
 import ParachainTable from "components/ParachainTable";
 import NavBar from "components/NavBar";
 import Footer from "components/Footer";
-import { ApiPromiseContextProvider } from "context";
+import { ApiPromiseContextProvider, RelayerContextProvider } from "context";
 
 const MainLayout = () => {
   return (
     <>
-      <NavBar/>
+      <NavBar />
 
       <ApiPromiseContextProvider>
-        <ParachainTable />
+        <RelayerContextProvider>
+          <ParachainTable />
+        </RelayerContextProvider>
       </ApiPromiseContextProvider>
 
-      <Footer/>
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
Several #62  changes.

## RPC Query updates

- [x] - For the first load. we must query feed data from the state and get the latest block and total sizes for each parachain.
- [x] - If the relayer is running in archive mode, we must query feeds from the state also. 
- [x]  - Every time a utility BatchCompleted extrinsic, need to refresh feed metadata.
- [ ] - Feed updates must accept both modes, from **state**(feeds.metadata) and **events** (dataSubmitted).
- [ ] - For each last record must allow showing the subspace block or hash where this block record was included.

