### PR TITLE
Frontend update react components

### DIFF
--- a/frontend/src/components/CardHeader.tsx
+++ b/frontend/src/components/CardHeader.tsx
@@ -1,0 +1,40 @@
+import { Card, CardBody, CardTitle, Row, Col, Spinner } from "reactstrap";
+
+const CardHeader = ({
+  title,
+  content,
+  md,
+}: {
+  title: string;
+  content: string;
+  md: string;
+}) => {
+  return (
+    <Col md={md}>
+      <Card className="card-stats mb-4 mb-xl-0">
+        <CardBody>
+          <Row>
+            <div className="col">
+              <CardTitle className="text-uppercase mb-0">
+                <h2 className="text-truncate">{title}</h2>
+                <h2 className="font-weight-bold text-primary">
+                  {content.length > 0 ? (
+                    content
+                  ) : (
+                    <Spinner
+                      className="ml-2"
+                      color="text-primary"
+                      size={"sm"}
+                    ></Spinner>
+                  )}
+                </h2>
+              </CardTitle>
+            </div>
+          </Row>
+        </CardBody>
+      </Card>
+    </Col>
+  );
+};
+
+export default CardHeader;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,15 +1,8 @@
 import { useContext, useEffect, useState } from "react";
 import { RelayerContext, SystemContext } from "context";
-import {
-  Card,
-  CardBody,
-  CardTitle,
-  Container,
-  Row,
-  Col,
-  Spinner,
-} from "reactstrap";
-import { allChains } from "config/AvailableParachain";
+import { Row, Container } from "reactstrap";
+import CardHeader from "./CardHeader";
+
 import { bytesToSize } from "./utils";
 
 const Header = () => {
@@ -32,100 +25,32 @@ const Header = () => {
     setAccumulatedObjects(newCount);
   }, [parachainFeeds]);
 
-  // TODO: Card to component.
   return (
-    <div className="header bg-gradient-gray-dark p-4 ">
+    <div className="header bg-gradient-gray-dark p-4">
       <Container fluid>
         <Row>
-          <Col md="2">
-            <Card className="card-stats mb-4 mb-xl-0">
-              <CardBody>
-                <Row>
-                  <div className="col">
-                    <CardTitle className="text-uppercase mb-0">
-                      <h2 className="text-truncate">Chains</h2>
-                      <h2 className="font-weight-bold text-primary">
-                        {allChains.length}
-                      </h2>
-                    </CardTitle>
-                  </div>
-                </Row>
-              </CardBody>
-            </Card>
-          </Col>
-          <Col md="4">
-            <Card className="card-stats mb-4 mb-xl-0">
-              <CardBody>
-                <Row>
-                  <div className="col">
-                    <CardTitle className="text-uppercase text-muted mb-0">
-                      <h2 className="text-truncate">Storage</h2>
-                      <h2 className="font-weight-bold text-primary">
-                        {accumulatedSizes ? (
-                          bytesToSize(accumulatedSizes)
-                        ) : (
-                          <Spinner
-                            className="ml-2"
-                            color="text-primary"
-                            size={"sm"}
-                          ></Spinner>
-                        )}
-                      </h2>
-                    </CardTitle>
-                  </div>
-                </Row>
-              </CardBody>
-            </Card>
-          </Col>
-          <Col md="4">
-            <Card className="card-stats mb-4 mb-xl-0">
-              <CardBody>
-                <Row>
-                  <div className="col">
-                    <CardTitle className="text-uppercase text-muted mb-0">
-                      <h2 className="text-truncate">Blocks Archived</h2>
-                      <h2 className="font-weight-bold text-primary">
-                        {accumulatedObjects ? (
-                          accumulatedObjects.toLocaleString()
-                        ) : (
-                          <Spinner
-                            className="ml-2"
-                            color="text-primary"
-                            size={"sm"}
-                          ></Spinner>
-                        )}
-                      </h2>
-                    </CardTitle>
-                  </div>
-                </Row>
-              </CardBody>
-            </Card>
-          </Col>
-
-          <Col md="2">
-            <Card className="card-stats mb-4 mb-xl-0">
-              <CardBody>
-                <Row>
-                  <div className="col">
-                    <CardTitle className="text-uppercase text-muted mb-0">
-                      <h2 className="text-truncate">Version</h2>
-                      <h2 className="font-weight-bold text-primary text-truncate">
-                        {version ? (
-                          version.substring(0, 5)
-                        ) : (
-                          <Spinner
-                            className="ml-2"
-                            color="text-primary"
-                            size={"sm"}
-                          ></Spinner>
-                        )}
-                      </h2>
-                    </CardTitle>
-                  </div>
-                </Row>
-              </CardBody>
-            </Card>
-          </Col>
+          <CardHeader
+            md="2"
+            title="Chains"
+            content={parachainFeeds.length > 0 ? parachainFeeds.length.toString() : ""}
+          />
+          <CardHeader
+            md="4"
+            title="Storage"
+            content={accumulatedSizes > 0 ? bytesToSize(accumulatedSizes) : ""}
+          />
+          <CardHeader
+            md="4"
+            title="Blocks Archived"
+            content={
+              accumulatedObjects > 0 ? accumulatedObjects.toLocaleString() : ""
+            }
+          />
+          <CardHeader
+            md="2"
+            title="Version"
+            content={version ? version.substring(0, 5) : ""}
+          />
         </Row>
       </Container>
     </div>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -24,12 +24,24 @@ const NavBar = () => {
           <span className="h1 nav-link-inner--text">Subspace Relayer</span>
         </NavItem>
       </Nav>
-      <Nav className="ml-auto">
-        <NavItem>
-          <span className="h5 text-gray nav-link-inner--text">
-            {"A permanent archival storage service for Polkadot and Kusama."}
-          </span>
-        </NavItem>
+      <Nav className="mx-auto">
+        {width > 920 && (
+          <NavItem>
+            <span className="h5 text-gray nav-link-inner--text">
+              {"A permanent archival storage service for Polkadot and Kusama."}
+            </span>
+            <a
+              rel="noreferrer"
+              href="https://www.parity.io/blog/subspace-archiving-kusama-with-onfinality"
+              target="_blank"
+              className="h5 text-primary nav-link-inner--text"
+            >
+              {"Learn more ..."}
+            </a>
+          </NavItem>
+        )}
+      </Nav>
+      <Nav className="mr-2 ml-4">
         {width > 920 && (
           <NavItem>
             <Badge className="ml-4 badge-dot">


### PR DESCRIPTION
# Description.

Separated changes for react components.

- CardHeader: Reusable Cards for Header.
- Header: Now uses CardHeader, also shows chains `count` from archive available chains.
- NavBar: Center title and add a link to parity post.