### PR TITLE
Front end - Automate deployment

### DIFF
--- a/.github/workflows/wrangler-publish.yaml
+++ b/.github/workflows/wrangler-publish.yaml
@@ -1,0 +1,31 @@
+name: wrangler-publish
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    name: Build App and Wrangler Publish.
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "16"
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+        env:
+          REACT_APP_WS_PROVIDER: ${{secrets.REACT_APP_WS_PROVIDER}}
+      - run: npm i -g @cloudflare/wrangler
+        working-directory: frontend
+      - run: 'wrangler publish'
+        working-directory: frontend
+        env:
+          CF_ACCOUNT_ID: ${{secrets.CF_ACCOUNT_ID}}
+          CF_ZONE_ID: ${{secrets.CF_ZONE_ID}}
+          CF_API_TOKEN: ${{secrets.CF_API_TOKEN}}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,4 +3,3 @@
 # wrangler files
 /dist
 /workers-site
-wrangler.toml

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,8 @@
   "browserslist": {
     "production": [
       ">0.2%",
+      "not ie <= 99",
+      "not android <= 4.4.4",
       "not dead",
       "not op_mini all"
     ],

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,0 +1,8 @@
+name = "relayer"
+type = "webpack"
+route = "testnet-relayer.subspace.network/*"
+usage_model = ""
+compatibility_flags = []
+workers_dev = false
+site = {bucket = "./build", entry-point = "workers-site"}
+compatibility_date = "2021-10-20"


### PR DESCRIPTION
# Summary 
- Closes #108 

## Description.

- Add Github workflow to automate **frontend** deployment.  Using wrangler CLI. 
  - Will run ON: `main` branch `push` and **only** if the `frontend` directory has new changes.

- Add `frontend/wrangler.toml`. Required by `wrangler publish`. Also need to create the following secrets to be used in the app build and publishing process.

- [ ] Add secrets on Project Settings. 

          REACT_APP_WS_PROVIDER: ${{secrets.REACT_APP_WS_PROVIDER}}
          CF_ACCOUNT_ID: ${{secrets.CF_ACCOUNT_ID}}
          CF_ZONE_ID: ${{secrets.CF_ZONE_ID}}
          CF_API_TOKEN: ${{secrets.CF_API_TOKEN}}