### PR TITLE
Update metadata handle

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,21 +8,19 @@ import { bytesToSize } from "./utils";
 const Header: React.FC = (): ReactElement => {
   const { version } = useContext(SystemContext);
   const { feeds } = useContext(RelayerContext);
-  const [accumulatedSizes, setAccumulatedSizes] = useState<number>(0);
-  const [accumulatedObjects, setAccumulatedObjects] = useState<number>(0);
+  const [totalSize, setTotalSize] = useState<number>(0);
+  const [totalCount, setTotalCount] = useState<number>(0);
 
   useEffect(() => {
     if (feeds.length === 0) return;
     let newSize = 0;
     let newCount = 0;
     for (const feedTotal of feeds) {
-      if (feedTotal) {
-        newSize += feedTotal.size;
-        newCount += feedTotal.count;
-      }
+      newSize += feedTotal.size;
+      newCount += feedTotal.count;
     }
-    setAccumulatedSizes(newSize);
-    setAccumulatedObjects(newCount);
+    setTotalSize(newSize);
+    setTotalCount(newCount);
   }, [feeds]);
 
   return (
@@ -37,13 +35,13 @@ const Header: React.FC = (): ReactElement => {
           <CardHeader
             md="4"
             title="Storage"
-            content={accumulatedSizes > 0 ? bytesToSize(accumulatedSizes) : ""}
+            content={totalSize > 0 ? bytesToSize(totalSize) : ""}
           />
           <CardHeader
             md="4"
             title="Blocks Archived"
             content={
-              accumulatedObjects > 0 ? accumulatedObjects.toLocaleString() : ""
+              totalCount > 0 ? totalCount.toLocaleString() : ""
             }
           />
           <CardHeader

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,10 +12,10 @@ const Header: React.FC = (): ReactElement => {
   const [totalCount, setTotalCount] = useState<number>(0);
 
   useEffect(() => {
-    if (feeds.length === 0) return;
+    if (feeds.size === 0) return;
     let newSize = 0;
     let newCount = 0;
-    for (const feedTotal of feeds) {
+    for (const feedTotal of feeds.values()) {
       newSize += feedTotal.size;
       newCount += feedTotal.count;
     }
@@ -30,7 +30,7 @@ const Header: React.FC = (): ReactElement => {
           <CardHeader
             md="2"
             title="Chains"
-            content={feeds.length > 0 ? feeds.length.toString() : ""}
+            content={feeds.size > 0 ? feeds.size.toString() : ""}
           />
           <CardHeader
             md="4"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -7,15 +7,15 @@ import { bytesToSize } from "./utils";
 
 const Header: React.FC = (): ReactElement => {
   const { version } = useContext(SystemContext);
-  const { parachainFeeds } = useContext(RelayerContext);
+  const { feeds } = useContext(RelayerContext);
   const [accumulatedSizes, setAccumulatedSizes] = useState<number>(0);
   const [accumulatedObjects, setAccumulatedObjects] = useState<number>(0);
 
   useEffect(() => {
-    if (parachainFeeds.length === 0) return;
+    if (feeds.length === 0) return;
     let newSize = 0;
     let newCount = 0;
-    for (const feedTotal of parachainFeeds) {
+    for (const feedTotal of feeds) {
       if (feedTotal) {
         newSize += feedTotal.size;
         newCount += feedTotal.count;
@@ -23,7 +23,7 @@ const Header: React.FC = (): ReactElement => {
     }
     setAccumulatedSizes(newSize);
     setAccumulatedObjects(newCount);
-  }, [parachainFeeds]);
+  }, [feeds]);
 
   return (
     <div className="header bg-gradient-gray-dark p-4">
@@ -32,7 +32,7 @@ const Header: React.FC = (): ReactElement => {
           <CardHeader
             md="2"
             title="Chains"
-            content={parachainFeeds.length > 0 ? parachainFeeds.length.toString() : ""}
+            content={feeds.length > 0 ? feeds.length.toString() : ""}
           />
           <CardHeader
             md="4"

--- a/frontend/src/components/ParachainTable.tsx
+++ b/frontend/src/components/ParachainTable.tsx
@@ -11,10 +11,10 @@ const ParachainTable: React.FC = (): ReactElement => {
   const [filter, setFilter] = useState<number>(0);
   const [sortByBlock, setSortByBlock] = useState<boolean>(true);
   const [sortedFeeds, setSortedFeeds] = useState<ParachainFeed[]>([]);
-  const { parachainFeeds } = useContext(RelayerContext);
+  const { feeds } = useContext(RelayerContext);
 
   useEffect(() => {
-    const sortedFeeds = parachainFeeds.sort((a, b) => {
+    const sortedFeeds = feeds.sort((a, b) => {
       // Set Polkadot to the top position on table
       if (a.feedId === 17 ) return -1;
       if (b.feedId === 17 ) return 1;
@@ -29,7 +29,7 @@ const ParachainTable: React.FC = (): ReactElement => {
       }
     });
     setSortedFeeds(sortedFeeds);
-  }, [parachainFeeds, sortByBlock]);
+  }, [feeds, sortByBlock]);
 
   const updateSortByBlock = () => {
     setSortByBlock(!sortByBlock);

--- a/frontend/src/components/ParachainTable.tsx
+++ b/frontend/src/components/ParachainTable.tsx
@@ -10,24 +10,25 @@ const ParachainTable: React.FC = (): ReactElement => {
   const [parachainProps] = useState<ParachainProps[]>([...allChains]);
   const [filter, setFilter] = useState<number>(0);
   const [sortByBlock, setSortByBlock] = useState<boolean>(true);
-  const [sortedFeeds, setSortedFeeds] = useState<ParachainFeed[]>([]);
+  const [sortedFeeds, setSortedFeeds] = useState<[number, ParachainFeed][]>([]);
   const { feeds } = useContext(RelayerContext);
 
   useEffect(() => {
-    const sortedFeeds = feeds.sort((a, b) => {
-      // Set Polkadot to the top position on table
-      if (a.feedId === 17 ) return -1;
-      if (b.feedId === 17 ) return 1;
-      // Set Kusama to the second position on table
-      if (a.feedId === 0 ) return -1;
-      if (b.feedId === 0 ) return 1;
+    const sortedFeeds = [...feeds.entries()]
+      .sort(([feedIdA, feedDataA], [feedIdB, feedDataB]) => {
+        // Set Polkadot to the top position on table
+        if (feedIdA === 17) return -1;
+        if (feedIdB === 17) return 1;
+        // Set Kusama to the second position on table
+        if (feedIdA === 0) return -1;
+        if (feedIdB === 0) return 1;
 
-      if (sortByBlock) {
-        return b.number - a.number;
-      } else {
-        return a.number - b.number;
-      }
-    });
+        if (sortByBlock) {
+          return feedDataB.number - feedDataA.number;
+        } else {
+          return feedDataA.number - feedDataB.number;
+        }
+      });
     setSortedFeeds(sortedFeeds);
   }, [feeds, sortByBlock]);
 
@@ -83,9 +84,9 @@ const ParachainTable: React.FC = (): ReactElement => {
               </tr>
             </thead>
             <tbody>
-              {sortedFeeds.map((feed) => {
-                const prop = parachainProps.find((p) => p.feedId === feed.feedId);
-                if (prop) return <ParachainRow key={feed.feedId} filter={filter} {...prop} {...feed} />;
+              {sortedFeeds.map(([feedId, feed]) => {
+                const prop = parachainProps.find((p) => p.feedId === feedId);
+                if (prop) return <ParachainRow key={feedId} filter={filter} {...prop} {...feed} />;
               })}
               {sortedFeeds.length === 0 && (
                 <tr>

--- a/frontend/src/context/interfaces/index.ts
+++ b/frontend/src/context/interfaces/index.ts
@@ -36,7 +36,7 @@ export interface ApiPromiseContextType {
 }
 
 export interface RelayerContextType {
-  parachainFeeds: ParachainFeed[];
+  feeds: ParachainFeed[];
 }
 
 export interface SystemContextType {

--- a/frontend/src/context/interfaces/index.ts
+++ b/frontend/src/context/interfaces/index.ts
@@ -36,7 +36,7 @@ export interface ApiPromiseContextType {
 }
 
 export interface RelayerContextType {
-  feeds: ParachainFeed[];
+  feeds: Map<number, ParachainFeed>;
 }
 
 export interface SystemContextType {

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,6 +1,6 @@
 name = "relayer"
 type = "webpack"
-route = "testnet-relayer.subspace.network/*"
+route = "aries-dev-relayer.subspace.network/*"
 usage_model = ""
 compatibility_flags = []
 workers_dev = false


### PR DESCRIPTION
- update metadata decoding (due to recent runtime changes)
- update feeds based on the new block events instead of processing extrinsics
- use Map to store feeds data instead of Array
- deploy UI to `aries-dev-relayer.subspace.network` (temporarily, to avoid breaking relayer on `test-a`)