### PR TITLE
Remove hardcoded feedIds

### DIFF
--- a/backend/src/tools/create-feeds.ts
+++ b/backend/src/tools/create-feeds.ts
@@ -53,7 +53,7 @@ async function getSetId(api: ApiPromise, blockHash: BlockHash) {
       const chainAccount = getAccount(`${fundsAccountSeed}//${chainConfig.feedId}`);
       logger.info(`Creating feed for account ${chainAccount.address}...`);
 
-      const isRelayChain = chainConfig.feedId === 0 || chainConfig.feedId === 17; // Kusama feeId: 0, Polkadot feedId: 17
+      const isRelayChain = chainConfig.feedId === config.primaryChain.feedId;
 
       let initialValidation;
 

--- a/frontend/src/components/ParachainTable.tsx
+++ b/frontend/src/components/ParachainTable.tsx
@@ -14,14 +14,17 @@ const ParachainTable: React.FC = (): ReactElement => {
   const { feeds } = useContext(RelayerContext);
 
   useEffect(() => {
+    // feedIds may change, so we find feedId by chain name before sorting
+    const kusamaFeedId = allChains.find(chain => chain.chainName === 'Kusama')?.feedId;
+    const polkadotFeedId = allChains.find(chain => chain.chainName === 'Polkadot')?.feedId;
     const sortedFeeds = [...feeds.entries()]
       .sort(([feedIdA, feedDataA], [feedIdB, feedDataB]) => {
         // Set Polkadot to the top position on table
-        if (feedIdA === 17) return -1;
-        if (feedIdB === 17) return 1;
+        if (feedIdA === polkadotFeedId) return -1;
+        if (feedIdB === polkadotFeedId) return 1;
         // Set Kusama to the second position on table
-        if (feedIdA === 0) return -1;
-        if (feedIdB === 0) return 1;
+        if (feedIdA === kusamaFeedId) return -1;
+        if (feedIdB === kusamaFeedId) return 1;
 
         if (sortByBlock) {
           return feedDataB.number - feedDataA.number;


### PR DESCRIPTION
Due to feed ownership introduction (on Subspace runtime), it is no longer possible to maintain the same feedId as we are addinng more parachains. This PR removes hardcoded feedIds for Kusama and Polkadot