### PR TITLE
add prod env to wrangler config

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,8 +1,11 @@
-name = "relayer"
 type = "webpack"
-route = "aries-dev-relayer.subspace.network/*"
-usage_model = ""
-compatibility_flags = []
-workers_dev = false
-site = {bucket = "./build", entry-point = "workers-site"}
+workers_dev = true
+site = { bucket = "build" }
+main = "workers-site/index.js"
 compatibility_date = "2021-10-20"
+name = "aries-dev-relayer-frontend"
+route = "aries-dev-relayer.subspace.network/*"
+
+[env.production]
+name = "relayer"
+route = "testnet-relayer.subspace.network/*"


### PR DESCRIPTION
I have used service names we already have: `relayer` (for production) and `aries-dev-relayer-frontend` (for relaynet). The new version will be deployed to the latter by default.